### PR TITLE
Gradle Kotlin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,5 @@
 apply plugin: 'com.android.application'
-
 apply plugin: 'kotlin-android'
-
 apply plugin: 'kotlin-android-extensions'
 
 android {
@@ -24,10 +22,11 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:28.0.0-alpha3'
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+
+    implementation"org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+
     ext.kotlin_version = '1.2.30'
+
     repositories {
         google()
         jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
+
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
# Gradle

The followings are step to add gradle dependencies configuration

* App Gradle
We should add <b>apply plugin: 'kotlin-android'</b> and <b>apply plugin: 'kotlin-android-extensions'</b> at the top of the file. The first file said that we're going to use Kotlin; the second one help us to take advantage of kotlin extensions.

* Project Gradle
The firs thing to is create a variable with kotlin version to mantain consistence wirth kotlin version throughout the app.
<b>ext.kotlin_version = '1.2.30'</b>
<b>Note:</b> this note should be write inside buildScript braces.

The second thing to do is added kotlin dependency into project gradle dependencies braces:
<b>classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"</b>
